### PR TITLE
feat: logic updates to make the strat more robust

### DIFF
--- a/tests/test_debt_limit.py
+++ b/tests/test_debt_limit.py
@@ -59,22 +59,22 @@ def test_increasing_debt_limit(
     assert strategy.estimatedTotalAssets() >= amount * 2
 
 
-# def test_decrease_debt_limit(
-#     StrategySushiswapPair, vault2, config, token, gov, whale, strategist
-# ):
-#     token.approve(vault2, 2 ** 256 - 1, {"from": whale})
-#     balanceOfWhale = token.balanceOf(whale)
-#     amount = balanceOfWhale // 2
+def test_decrease_debt_limit(
+    StrategySushiswapPair, vault2, config, token, gov, whale, strategist
+):
+    token.approve(vault2, 2 ** 256 - 1, {"from": whale})
+    balanceOfWhale = token.balanceOf(whale)
+    amount = balanceOfWhale // 2
 
-#     strategy = StrategySushiswapPair.deploy(vault2, config["pid"], {"from": strategist})
-#     vault2.addStrategy(strategy, amount, 2 ** 256 - 1, 0, {"from": gov})
-#     vault2.deposit(amount-1, {"from": whale})
-#     strategy.harvest({"from": strategist})
-#     assert strategy.estimatedTotalAssets() >= amount-1
+    strategy = StrategySushiswapPair.deploy(vault2, config["pid"], {"from": strategist})
+    vault2.addStrategy(strategy, amount, 2 ** 256 - 1, 0, {"from": gov})
+    vault2.deposit(amount-1, {"from": whale})
+    strategy.harvest({"from": strategist})
+    assert strategy.estimatedTotalAssets() >= amount-1
 
-#     vault2.updateStrategyDebtLimit(strategy, amount // 2, {"from": gov})
-#     assert vault2.debtOutstanding(strategy) >= ((amount // 2) - 1)
-#     strategy.harvest({"from": strategist})
+    vault2.updateStrategyDebtLimit(strategy, amount // 2, {"from": gov})
+    assert vault2.debtOutstanding(strategy) >= ((amount // 2) - 1)
+    strategy.harvest({"from": strategist})
 
-#     assert strategy.estimatedTotalAssets() >= amount // 2
-#     assert token.balanceOf(vault2) >= amount // 2 
+    assert strategy.estimatedTotalAssets() >= amount // 2
+    assert token.balanceOf(vault2) >= amount // 2 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -51,7 +51,9 @@ def test_strategy_harvest(strategy, vault, token, whale, chain, chef, xsushi, su
 
     # We need to simulate sushi trading to earn some fees. We skip this by sending sushi to the sushi bar
     sushi.transfer(xsushi, 5000000000000000000000, {"from": sushiwhale})
+    assert strategy.harvestTrigger(100)
     strategy.harvest()
+    assert not strategy.harvestTrigger(100)
     assert weth.balanceOf(strategy) < 1000000000000
 
     print("Sushi Chef balance:", chef.userInfo(strategy.pid(), strategy))


### PR DESCRIPTION
In this PR I:
- overrode `harvestTrigger` to account for xsushi staking and convert ETH to WANT so we can use keep3r network
- moved the transfer from xsushi from `prepareMigration` to `exitPosition`. This way sushi is always sent to gov when the contract is being moved on from
- added profit logic to `adjustPosition`
- updated `liquidatePosition` to not fail is _amount > balance of want (even though I do not think this could ever happen)